### PR TITLE
Fix light mode follow artist colour + remove boarder

### DIFF
--- a/index.less
+++ b/index.less
@@ -1071,7 +1071,7 @@
                 color: var(--textColor);
                 
                 .artist-chip__follow {
-                    color: var(--textColor);
+                    color: var(--KeyColor);
                     background-color: transparent;
                 }
             }

--- a/index.less
+++ b/index.less
@@ -1069,6 +1069,11 @@
             // }
             .artist-chip {
                 color: var(--textColor);
+                
+                .artist-chip__follow {
+                    color: var(--textColor);
+                    background-color: transparent;
+                }
             }
 
 


### PR DESCRIPTION
This PR will fix the colour of the follow artist in Light Mode. Previously it was white but now it will be black. This will also remove the circle boarder around the + and tick button to fit in line with iThemes style to be like MacOS AM.