### PR TITLE
Improve light mode sidebar + AppleDrawers

### DIFF
--- a/index.less
+++ b/index.less
@@ -33,7 +33,7 @@
         --UIKitShadow             : 0px 0px 36px 0px rgba(0, 0, 0, 0.3);
         --checked                 : rgb(77, 202, 77);
         --searchBarBackgroundColor: rgba(0, 0, 0, 0.3);
-        --searchBackgroundColor   : rgba(83, 83, 83, 0.6);
+        --searchBackgroundColor   : rgba(31, 31, 31, 0.6);
         --activeTabColor          : rgba(250, 88, 106, 0.1);
         --oddItemsAccentCOlor     : rgb(255 255 255 / 0.03);
         --sidebarIconColor        : rgba(255, 255, 255, 0.5);
@@ -1351,7 +1351,7 @@
             --UIKitBlackTextColor     : rgba(50, 50, 50, 0.75);
             --UIKitSelected           : rgba(200, 200, 200, 0.15);
             --checked                 : rgb(77, 202, 77);
-            --searchBarBackgroundColor: rgb(233, 233, 233);
+            --searchBarBackgroundColor: white;
             --searchBackgroundColor   : rgba(145, 143, 143, 0.3);
             --activeTabColor          : rgba(100, 100, 107, 0.25);
             --oddItemsAccentCOlor     : rgba(0, 0, 0, 0.05);
@@ -1750,7 +1750,7 @@
         --UIKitSelected           : rgba(200, 200, 200, 0.15);
         --checked                 : rgb(77, 202, 77);
         --searchBarBackgroundColor: white; 
-        --searchBackgroundColor   : rgba(255, 255, 255, 0.3);
+        --searchBackgroundColor   : rgba(145, 143, 143, 0.3);
         --activeTabColor          : rgba(100, 100, 107, 0.25);
         --oddItemsAccentCOlor     : rgba(0, 0, 0, 0.05);
         --userHoverColor          : rgba(250, 35, 59, 0.4);

--- a/index.less
+++ b/index.less
@@ -33,7 +33,7 @@
         --UIKitShadow             : 0px 0px 36px 0px rgba(0, 0, 0, 0.3);
         --checked                 : rgb(77, 202, 77);
         --searchBarBackgroundColor: rgba(0, 0, 0, 0.3);
-        --searchBackgroundColor   : rgba(31, 31, 31, 0.6);
+        --searchBackgroundColor   : rgba(83, 83, 83, 0.6);
         --activeTabColor          : rgba(250, 88, 106, 0.1);
         --oddItemsAccentCOlor     : rgb(255 255 255 / 0.03);
         --sidebarIconColor        : rgba(255, 255, 255, 0.5);
@@ -1351,8 +1351,8 @@
             --UIKitBlackTextColor     : rgba(50, 50, 50, 0.75);
             --UIKitSelected           : rgba(200, 200, 200, 0.15);
             --checked                 : rgb(77, 202, 77);
-            --searchBarBackgroundColor: white;
-            --searchBackgroundColor   : rgba(255, 255, 255, 0.3);
+            --searchBarBackgroundColor: rgb(233, 233, 233);
+            --searchBackgroundColor   : rgba(145, 143, 143, 0.3);
             --activeTabColor          : rgba(100, 100, 107, 0.25);
             --oddItemsAccentCOlor     : rgba(0, 0, 0, 0.05);
             --userHoverColor          : rgba(250, 35, 59, 0.4);
@@ -1539,6 +1539,7 @@
         }
 
         #app-sidebar {
+            background: var(--searchBackgroundColor);
             .search-input--icon {
                 filter: invert(0.8);
             }
@@ -1748,7 +1749,7 @@
         --UIKitBlackTextColor     : rgba(50, 50, 50, 0.75);
         --UIKitSelected           : rgba(200, 200, 200, 0.15);
         --checked                 : rgb(77, 202, 77);
-        --searchBarBackgroundColor: white;
+        --searchBarBackgroundColor: white; 
         --searchBackgroundColor   : rgba(255, 255, 255, 0.3);
         --activeTabColor          : rgba(100, 100, 107, 0.25);
         --oddItemsAccentCOlor     : rgba(0, 0, 0, 0.05);


### PR DESCRIPTION
Improves the colour to the AppleDrawers instead of being solid white, now they have a light grey colour that also is applied to the sidebar when Mica is turned off. Using system theme and Force Light Mode are both supported.