### PR TITLE
Improve light mode AppleDrawers colours

### DIFF
--- a/index.less
+++ b/index.less
@@ -1352,7 +1352,7 @@
             --UIKitSelected           : rgba(200, 200, 200, 0.15);
             --checked                 : rgb(77, 202, 77);
             --searchBarBackgroundColor: white;
-            --searchBackgroundColor   : rgba(255, 255, 255, 0.3);
+            --searchBackgroundColor   : rgba(115, 115, 115, 0.4);
             --activeTabColor          : rgba(100, 100, 107, 0.25);
             --oddItemsAccentCOlor     : rgba(0, 0, 0, 0.05);
             --userHoverColor          : rgba(250, 35, 59, 0.4);
@@ -1749,7 +1749,7 @@
         --UIKitSelected           : rgba(200, 200, 200, 0.15);
         --checked                 : rgb(77, 202, 77);
         --searchBarBackgroundColor: white;
-        --searchBackgroundColor   : rgba(255, 255, 255, 0.3);
+        --searchBackgroundColor   : rgba(115, 115, 115, 0.4);
         --activeTabColor          : rgba(100, 100, 107, 0.25);
         --oddItemsAccentCOlor     : rgba(0, 0, 0, 0.05);
         --userHoverColor          : rgba(250, 35, 59, 0.4);


### PR DESCRIPTION
Sets AppleDrawer color to follow the sidebar for a more consistent look, works with both System Theme and Force Light Mode.