### PR TITLE
fix: raise nav button `z-index`

### DIFF
--- a/index.less
+++ b/index.less
@@ -566,6 +566,10 @@
                 z-index: 2;
             }
 
+            .v-hl-btn[data-v-45080727] {
+                z-index: 2;
+            }
+
             .v-hl-container[data-v-45080727] {
                 clip-path    : none;
                 overflow-y   : visible;
@@ -755,7 +759,7 @@
                 .artist-title {
                     color: var(--textColor);
                 }
-                
+
                 .artist-header {
                     color: var(--textColor)
                 }
@@ -988,7 +992,7 @@
 
             &.playlist-page {
                 &[is-album="true"] {
-                    
+
                     .subtitle {
                         display: none !important;
                     }
@@ -999,9 +1003,9 @@
                 }
 
                 &[is-album="false"] {
-                    
+
                 }
-                
+
                 .artist-chip {
                     color: var(--textColor);
 


### PR DESCRIPTION
Raise nav button `z-index` that caused clipping and difficulty in clicking the element for it shares the same `z-index: 1` with the container.
Resolves #46 

![image](https://user-images.githubusercontent.com/77577746/179536136-5802ee3d-1207-4afc-aa4c-faf33cea6335.png)
![image](https://user-images.githubusercontent.com/77577746/179536093-88144d90-e503-443b-9e90-006458a7e8de.png)
